### PR TITLE
Settings: Lets remove Performance tab tile if no overlays are set

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -1228,7 +1228,7 @@ public class SettingsActivity extends Activity
                         removeTile = true;
                     }
                 } else if (id == R.id.performance_settings) {
-                    if (!(pm.hasPowerProfiles() || (showDev && !Build.TYPE.equals("user")))) {
+                    if (!(pm.hasPowerProfiles())) {
                         removeTile = true;
                     }
                 }


### PR DESCRIPTION
  * Remove logic to show if dev options are enabled

Change-Id: I115976b14a5caa2779906b5f52e70d5e9f1c3b34
Signed-off-by: Josue Rivera <prbassplayer@gmail.com>