### PR TITLE
Development settings: Remove icon from root dialog

### DIFF
--- a/src/com/android/settings/DevelopmentSettings.java
+++ b/src/com/android/settings/DevelopmentSettings.java
@@ -1693,7 +1693,6 @@ public class DevelopmentSettings extends SettingsPreferenceFragment
                 mRootDialog = new AlertDialog.Builder(getActivity())
                         .setMessage(getResources().getString(R.string.root_access_warning_message))
                         .setTitle(R.string.root_access_warning_title)
-                        .setIcon(android.R.drawable.ic_dialog_alert)
                         .setPositiveButton(android.R.string.yes, this)
                         .setNegativeButton(android.R.string.no, this).show();
                 mRootDialog.setOnDismissListener(this);


### PR DESCRIPTION
* Other dialogs in development settings don't have an icon anymore

Change-Id: If7784cf8d758ccce6d8dd3c2bae49ec8c6303336